### PR TITLE
feat: add scheduled weekly release workflow

### DIFF
--- a/.github/workflows/scheduled-release.yml
+++ b/.github/workflows/scheduled-release.yml
@@ -1,0 +1,92 @@
+name: Scheduled Release
+
+on:
+  schedule:
+    - cron: '0 9 * * MON'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  check-and-release:
+    name: Check commits and bump version
+    runs-on: ubuntu-latest
+    outputs:
+      should_release: ${{ steps.commit_check.outputs.should_release }}
+      new_version: ${{ steps.bump_version.outputs.new_version }}
+      commit_count: ${{ steps.commit_check.outputs.commit_count }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Check for commits since last release
+        id: commit_check
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+
+          if [ -z "$LAST_TAG" ]; then
+            COMMITS=1
+            SHOULD_RELEASE="true"
+          else
+            COMMITS=$(git rev-list ${LAST_TAG}..HEAD --count 2>/dev/null || echo "0")
+            if [ "$COMMITS" -gt "0" ]; then
+              SHOULD_RELEASE="true"
+            else
+              SHOULD_RELEASE="false"
+            fi
+          fi
+
+          echo "commit_count=$COMMITS" >> $GITHUB_OUTPUT
+          echo "should_release=$SHOULD_RELEASE" >> $GITHUB_OUTPUT
+          echo "Last tag: $LAST_TAG"
+          echo "Commits since: $COMMITS"
+
+      - name: Bump version (minor)
+        if: steps.commit_check.outputs.should_release == 'true'
+        id: bump_version
+        run: |
+          CURRENT_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\([^"]*\)"/\1/')
+          uv version --bump minor
+          NEW_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\([^"]*\)"/\1/')
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "Bumped from $CURRENT_VERSION to $NEW_VERSION"
+
+      - name: Commit version bump
+        if: steps.commit_check.outputs.should_release == 'true'
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add pyproject.toml
+          git commit -m "chore: bump version to ${{ steps.bump_version.outputs.new_version }}"
+
+      - name: Push changes
+        if: steps.commit_check.outputs.should_release == 'true'
+        run: |
+          git push origin main
+
+  publish-release:
+    name: Create GitHub Release
+    needs: check-and-release
+    if: needs.check-and-release.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create v${{ needs.check-and-release.outputs.new_version }} \
+            --title "v${{ needs.check-and-release.outputs.new_version }}" \
+            --notes "Release of version ${{ needs.check-and-release.outputs.new_version }} with ${{ needs.check-and-release.outputs.commit_count }} commit(s)."


### PR DESCRIPTION
Automatically bump minor version and create releases on Monday at 9 AM UTC, but only if there have been commits since the last release.